### PR TITLE
add egfURI parameter to swagger

### DIFF
--- a/api/toip-tswg-trustregistryprotocol-v2.yaml
+++ b/api/toip-tswg-trustregistryprotocol-v2.yaml
@@ -97,6 +97,17 @@ paths:
             The identifier of the Authorization that is being queried for this
             Entity.
           allowReserved: true
+        - in: query
+          name: egfURI
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uri'
+          description: >
+            The URI-based identifier of the Ecosystem Governance Framework that
+            the assurance levels apply to. Allows reserved characters per
+            RFC3986. 
+            Do **NOT** escape the URI.        
+          allowReserved: true
       responses:
         '200':
           description: search results matching criteria
@@ -126,6 +137,17 @@ paths:
             reserved characters per RFC3986. 
 
             Do **NOT** escape the URI.
+          allowReserved: true
+        - in: query
+          name: egfURI
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uri'
+          description: >
+            The URI-based identifier of the Ecosystem Governance Framework that
+            the assurance levels apply to. Allows reserved characters per
+            RFC3986. 
+            Do **NOT** escape the URI.        
           allowReserved: true
       responses:
         '200':


### PR DESCRIPTION
When we are asking about authorizations of an entity in context of the TRQP, we are asking _bound_ to the context of a EGF. Therefore, I am adding egfURI as a _required_ parameter. 

For now, I am adding it as part of the query to not override the existing API boundary, but this might need to be part of the path. 